### PR TITLE
Fix query parameter defaults

### DIFF
--- a/src/SigV4RequestSigner.spec.ts
+++ b/src/SigV4RequestSigner.spec.ts
@@ -84,5 +84,16 @@ describe('SigV4RequestSigner', () => {
         it('should generate a valid signed URL without a mocked date', async () => {
             await expect(signer.getSignedURL('wss://kvs.awsamazon.com', queryParams)).resolves.toBeTruthy();
         });
+
+        it ('should generate a valid signed URL with query parameter override', async () => {
+            signer = new SigV4RequestSigner(region, credentials);
+            queryParams = {
+                'X-Amz-TestParam': 'test-param-value',
+                'X-Amz-Expires': '86400', // should override the default of 299 seconds
+            };
+            await expect(signer.getSignedURL('wss://kvs.awsamazon.com', queryParams, date)).resolves.toBe(
+                'wss://kvs.awsamazon.com/?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIA4F7WJQR7FMMWMNXI%2F20191201%2Fus-west-2%2Fkinesisvideo%2Faws4_request&X-Amz-Date=20191201T000000Z&X-Amz-Expires=86400&X-Amz-Security-Token=FakeSessionToken&X-Amz-Signature=b62a078631a8f1e31ad09bce25d251611a22b65eac8836f6d700cee50a04e9e1&X-Amz-SignedHeaders=host&X-Amz-TestParam=test-param-value'
+            );
+        })
     });
 });

--- a/src/SigV4RequestSigner.ts
+++ b/src/SigV4RequestSigner.ts
@@ -74,13 +74,13 @@ export class SigV4RequestSigner implements RequestSigner {
 
         // Prepare canonical query string
         const credentialScope = dateString + '/' + this.region + '/' + this.service + '/' + 'aws4_request';
-        const canonicalQueryParams = Object.assign({}, queryParams, {
+        const canonicalQueryParams = Object.assign({}, {
             'X-Amz-Algorithm': SigV4RequestSigner.DEFAULT_ALGORITHM,
             'X-Amz-Credential': this.credentials.accessKeyId + '/' + credentialScope,
             'X-Amz-Date': datetimeString,
             'X-Amz-Expires': '299',
             'X-Amz-SignedHeaders': signedHeaders,
-        });
+        }, queryParams);
         if (this.credentials.sessionToken) {
             Object.assign(canonicalQueryParams, {
                 'X-Amz-Security-Token': this.credentials.sessionToken,


### PR DESCRIPTION
### Why
There a some reserved query parameters that are overridden despite user input... most notably, the `X-Amz-Expires` parameter is set to a static 299 seconds.

### How
Spread the user-defined query parameters last, allowing them to override defaults.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
